### PR TITLE
[FIX] Deprecation on :public_dir in configuration

### DIFF
--- a/lib/castronaut/application.rb
+++ b/lib/castronaut/application.rb
@@ -53,7 +53,7 @@ module Castronaut
       set :root,         root
       set :app_file,     app_file
       set :views,        views
-      set :public,       pub_dir
+      set :public_dir,   pub_dir
       set :logging,      true
       set :raise_errors, true
       set :run,          false


### PR DESCRIPTION
This removes this deprecation warning when running `devise_cas_authenticable` test suite and using `castronaut` as CAS server.

```
:public is no longer used to avoid overloading Module#public, use :public_folder or :public_dir instead
    from /castronaut/lib/castronaut/application.rb:56:in `block in <class:Application>'
```
